### PR TITLE
Solving a bug in generatecontour.js

### DIFF
--- a/examples/contourline.js
+++ b/examples/contourline.js
@@ -1,0 +1,58 @@
+function draw(){
+// Generate contour data
+	var contourFunction = function( x, y, obj ) {
+	  var val =  (x*y) ;
+	  obj.minZ = Math.min( val, obj.minZ );
+	  obj.maxZ = Math.max( val, obj.maxZ );
+	  return val;
+	} 
+
+	var obj = {
+	  noise: 0,
+	  minZ: Number.POSITIVE_INFINITY,
+	  maxZ: Number.NEGATIVE_INFINITY,
+	  z: [],
+	  minX: 0.09,
+	  maxX: 0.16,
+	  minY: 50,
+	  maxY: 180
+	};
+	console.log('antes ciclo');
+	var i = 0, j;
+	for( var x = obj.minX; x < obj.maxX; x += 0.0005 ) {
+	  j = 0;
+	  obj.z[ i ] = [];
+	  for( var y = obj.minY; y < obj.maxY ; y += 0.05 ) {
+	    obj.z[ i ][ j ] = contourFunction( x, y, obj );
+	    j++;
+	  }
+	  i++;
+	};
+	
+	console.log('despues ciclo');
+
+	var g = new Graph("curva");
+
+	var dataContour = generateContourLines( obj );
+
+	console.log(dataContour);
+
+	var s2 = g.newSerie("s2", {}, "contour")
+	  .autoAxis()
+	  .setData( {
+
+	    minX: obj.minX,
+	    maxX: obj.maxX,
+	    minY: obj.minY,
+	    maxY: obj.maxY,
+	    segments: dataContour
+
+	  } );
+  	console.log('antes dibujar');
+	g.redraw();
+	g.drawSeries();
+	console.log('despues dibujar');
+	
+};
+
+//draw();

--- a/examples/generatecontour.js
+++ b/examples/generatecontour.js
@@ -18,8 +18,8 @@ return function generateContourLines(zData) {
     var povarHeight = new Float32Array(4);
     var isOver = [];
 
-    var nbSubSpectra=z.length;
-    var nbPovars=z[0].length;
+    var nbSubSpectra=z[0].length;
+    var nbPovars=z.length;
     var pAx, pAy, pBx, pBy;
 
     var x0 = zData.minX;
@@ -60,10 +60,10 @@ return function generateContourLines(zData) {
         
         for (var iSubSpectra = 0; iSubSpectra < nbSubSpectra - 1; iSubSpectra++) {
             for (var povar = 0; povar < nbPovars - 1; povar++) {
-                povarHeight[0] = z[iSubSpectra][povar];
-                povarHeight[1] = z[iSubSpectra][povar + 1];
-                povarHeight[2] = z[(iSubSpectra + 1)][povar];
-                povarHeight[3] = z[(iSubSpectra + 1)][(povar + 1)];
+                povarHeight[0] = z[povar][iSubSpectra];
+                povarHeight[1] = z[povar][iSubSpectra + 1];
+                povarHeight[2] = z[(povar + 1)][iSubSpectra];
+                povarHeight[3] = z[(povar + 1)][(iSubSpectra + 1)];
 
                 for (var i = 0; i < 4; i++) {
                     isOver[i] = (povarHeight[i] > lineZValue);

--- a/examples/indexo.html
+++ b/examples/indexo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+	<head>
+
+		<script src="../dist/jquery.min.js" type="text/javascript"></script>	
+		<script src="../dist/jsgraph.js" type="text/javascript"></script>	
+		
+		<script src="generatecontour.js" type="text/javascript"></script>	
+		<script src="contourline.js" type="text/javascript"></script>	
+		<script type="text/javascript"> 
+		$(document).ready(function(){
+			draw();
+		});
+			
+		</script>
+		
+
+
+
+	</head>
+
+	<body>
+
+		 <div id="curva"  style="height: 500px">
+      </div>
+
+	</body>
+</html>


### PR DESCRIPTION
Hi.

I was working with your library for creating a "Curva de Isoproductividad". So i was trying to draw a contour line of the function f(z) = x*y when I found a bug in generatecontout.js, some of the coordinates was bartered, X instead of Y, and Y instead of X. I am commiting the example that i use for figure out the error. You can see the differences. 